### PR TITLE
Just a little typo in react apollo

### DIFF
--- a/content/frontend/react-apollo/2-queries-loading-links.md
+++ b/content/frontend/react-apollo/2-queries-loading-links.md
@@ -261,4 +261,4 @@ That's it! You should see the exact same screen as before.
 > the server needs to run as well - so you have two running
 > processes in your terminal: One for the server and one for
 > the React app. To start the server, navigate into the
-> `server` directory and run `yarn start`.
+> `server` directory and run `yarn dev`.


### PR DESCRIPTION
For running the server of this project `yarn dev` is used not yarn start.